### PR TITLE
Support numberBetween(min, max)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Field values can be one of:
 - A call to `oneOf`. This takes any number of primitive values, and picks one at random.
 - A call to `arrayOf`. This takes any value (including another builder) and generates an array of them. It also takes the array `length` as the second argument: `arrayOf('foo', 2)` will generate `['foo', 'foo']`. `arrayOf(fake(f => f.name.findName()), 5)` will generate an array of 5 random names.
 - A call to `bool`. This is a shortcut for `oneOf(true, false)` and will pick one of them at random.
+- A call to `numberBetween`. This takes two arguments as min/max, and generates a random integer between them. `numberBetween(0, 10)` is a shortcut for `fake(f => f.random.number({ min: 0, max: 10 })`.
 
 ## Mapping
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,8 @@ const arrayOf = (builder, count = 1) =>
 
 const bool = () => oneOf(true, false)
 
+const numberBetween = (min, max) => fake(f => f.random.number({ min, max }))
+
 module.exports = {
   build,
   arrayOf,
@@ -99,4 +101,5 @@ module.exports = {
   incrementingId,
   oneOf,
   bool,
+  numberBetween,
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,6 +7,7 @@ const {
   oneOf,
   bool,
   arrayOf,
+  numberBetween,
 } = require('./index')
 
 expect.extend({
@@ -173,6 +174,25 @@ describe('generating fake items', () => {
     })
     const user = userBuilder()
     expect(user.isAdmin).toBeTrueOrFalse()
+  })
+
+  it('defines numberBetween to return a random integer between from min to max ', () => {
+    const [min, max] = [-1, 1]
+    const accountBuilder = build('Account').fields({
+      balance: numberBetween(min, max),
+    })
+    const account = accountBuilder()
+    expect(account.balance >= min).toBeTruthy()
+    expect(account.balance <= max).toBeTruthy()
+  })
+
+  it('lets a random number by numberBetween be overriden to be another number outside given range', () => {
+    const [min, max] = [-1, 1]
+    const accountBuilder = build('Account').fields({
+      balance: numberBetween(min, max),
+    })
+    const account = accountBuilder({ balance: -100 })
+    expect(account.balance).toBe(-100)
   })
 
   it('allows deeply nested fake data', () => {


### PR DESCRIPTION
Fixes #5.

`numberBetween(0, 10)` is a shortcut for `fake(f => f.random.number({ min: 0, max: 10 })`.