### PR TITLE
Add homepage, bugs and repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "test"
   ],
   "author": "Jack Franklin",
+  "homepage": "https://github.com/jackfranklin/test-data-bot#readme",
+  "bugs": "https://github.com/jackfranklin/test-data-bot/issues",
+  "repository": "github:jackfranklin/test-data-bot",
   "license": "MIT",
   "devDependencies": {
     "eslint": "5.15.3",


### PR DESCRIPTION
Fixes #48.

Add missing homepage, bugs and repository fields from package.json.

Field's taken from https://docs.npmjs.com/files/package.json.