### PR TITLE
chore: fix repository entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   "author": "Jack Franklin",
   "homepage": "https://github.com/jackfranklin/test-data-bot#readme",
   "bugs": "https://github.com/jackfranklin/test-data-bot/issues",
-  "repository": "github:jackfranklin/test-data-bot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jackfranklin/test-data-bot.git"
+  },
   "license": "MIT",
   "devDependencies": {
     "eslint": "5.16.0",


### PR DESCRIPTION
It wasn't showing up on the npm page properly.


![image](https://user-images.githubusercontent.com/1500684/55718482-09380980-59b9-11e9-9858-d2fd4571b6f9.png)
