### PR TITLE
Call postBuild and map after overriding all fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,6 @@ module.exports = {
     'prettier/prettier': ['error'],
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
 
     // rules from eslint-plugin-jest
     'jest/no-disabled-tests': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'prettier/prettier': ['error'],
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
 
     // rules from eslint-plugin-jest
     'jest/no-disabled-tests': 'error',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -355,5 +355,43 @@ describe('test-data-bot', () => {
         admin: expect.any(Boolean),
       });
     });
+
+    it('does not call postBuild on nested objects', () => {
+      expect.assertions(1);
+      interface User {
+        name: string;
+        sports: {
+          football: boolean;
+          basketball: boolean;
+          rugby: boolean;
+        };
+      }
+
+      const userBuilder = build<User>('User', {
+        postBuild: user => ({
+          ...user,
+          name: 'new name',
+        }),
+        fields: {
+          name: 'old name',
+          sports: {
+            football: true,
+            basketball: false,
+            rugby: true,
+          },
+        },
+      });
+
+      const user = userBuilder();
+
+      expect(user).toEqual({
+        name: 'new name',
+        sports: {
+          football: true,
+          basketball: false,
+          rugby: true,
+        },
+      });
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,21 +78,16 @@ export const build = <FactoryResultType>(
     fields: FieldsConfiguration<FactoryResultType>,
     buildTimeConfig: BuildTimeConfig<FactoryResultType> = {}
   ): { [P in keyof FieldsConfiguration<FactoryResultType>]: any } => {
-    const postBuild = config.postBuild || identity;
+    const finalBuiltThing = mapValues(fields, (fieldValue, fieldKey) => {
+      const overrides = buildTimeConfig.overrides || {};
 
-    const finalBuiltThing = postBuild(
-      mapValues(fields, (fieldValue, fieldKey) => {
-        const overrides = buildTimeConfig.overrides || {};
+      const valueOrOverride = overrides[fieldKey] || fieldValue;
 
-        const valueOrOverride = overrides[fieldKey] || fieldValue;
+      /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+      return expandConfigField(valueOrOverride);
+    });
 
-        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        return expandConfigField(valueOrOverride);
-      })
-    );
-
-    const buildTimeMapFunc = buildTimeConfig.map || identity;
-    return buildTimeMapFunc(finalBuiltThing);
+    return finalBuiltThing;
   };
 
   const expandConfigField = (
@@ -144,7 +139,10 @@ export const build = <FactoryResultType>(
 
   return (buildTimeConfig = {}) => {
     const fieldsToReturn = expandConfigFields(config.fields, buildTimeConfig);
-    return fieldsToReturn;
+    const postBuild = config.postBuild || identity;
+    const buildTimeMapFunc = buildTimeConfig.map || identity;
+
+    return buildTimeMapFunc(postBuild(fieldsToReturn));
   };
 };
 


### PR DESCRIPTION
# 💃 What
Hi! Thanks so much for this great library. 🎉 I work at a company in Melbourne and we use it in our test suite. This is a PR that addresses a recent issue filed for nested objects. Specifically, these changes:
- Ensure that `postBuild` is not run on nested objects. Fixes #173 
- Unit test added.
- Allow `any` to be used without eslint throwing warnings (not super necessary but seeing as there are plenty of valid uses of `any`, it made sense to me to allow it as a rule).
# 🎃 Why
So that `postBuild` can mimic the behaviour of the old `.map`
# 🌊 How
By moving the call to `postBuild` and `map` (build config version) after the given fields have been expanded and overridden.