### PR TITLE
Move faker into prod libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -626,8 +626,7 @@
     "@types/faker": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@types/faker/-/faker-4.1.10.tgz",
-      "integrity": "sha512-Z1UXXNyxUcuu7CSeRmVizMgH7zVYiwfiTgXMnSTvsYDUnVt3dbMSpPdfG/H41IBiclgFGQJgLVdDFeinhhmWTg==",
-      "dev": true
+      "integrity": "sha512-Z1UXXNyxUcuu7CSeRmVizMgH7zVYiwfiTgXMnSTvsYDUnVt3dbMSpPdfG/H41IBiclgFGQJgLVdDFeinhhmWTg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "url": "https://github.com/jackfranklin/test-data-bot.git"
   },
   "devDependencies": {
-    "@types/faker": "^4.1.9",
     "@types/jest": "^25.1.1",
     "@types/lodash": "^4.14.149",
     "@types/node": "^13.5.2",
@@ -49,6 +48,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "@types/faker": "^4.1.9",
     "faker": "4.1.0",
     "lodash": "^4.17.15"
   }


### PR DESCRIPTION
So that it's shipped and users will get type support when they install
test-data-bot.