### PR TITLE
Make factory name an optional argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn add --dev @jackfranklin/test-data-bot
 
 ## Creating your first builder
 
-We use the `build` function to create a builder. It takes a name for the object it will create, and then some fields:
+We use the `build` function to create a builder. You give a builder an object of fields you want to define:
 
 ```js
 const { build } = require('@jackfranklin/test-data-bot');
@@ -44,6 +44,18 @@ console.log(user);
 ```
 
 _While the examples in this README use `require`, you can also use `import {build} from '@jackfranklin/test-data-bot'`._
+
+**Note**: if you're using *Version 1.2 or higher* you can leave the name of the factory and pass in only the configuration object:
+
+```js
+const userBuilder = build({
+  fields: {
+    name: 'jack',
+  },
+});
+```
+
+Feel free to use the name property if you like, but it's not used for anything in test-data-bot. It will probably get removed in a future major version.
 
 Once you've created a builder, you can call it to generate an instance of that object - in this case, a `user`.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,23 @@
 import { build, sequence, fake, oneOf, bool, perBuild } from './index';
 
 describe('test-data-bot', () => {
+  it('can build an object with no name', () => {
+    interface User {
+      name: string;
+    }
+
+    const userBuilder = build<User>({
+      fields: {
+        name: 'jack',
+      },
+    });
+
+    const user = userBuilder();
+    expect(user).toEqual({
+      name: 'jack',
+    });
+  });
+
   it('can build an object with primitive values only', () => {
     interface User {
       name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,11 +69,15 @@ type ValueOf<T> = T[keyof T];
 const identity = <T>(x: T): T => x;
 
 export const build = <FactoryResultType>(
-  factoryName: string,
-  config: BuildConfiguration<FactoryResultType>
+  factoryNameOrConfig: string | BuildConfiguration<FactoryResultType>,
+  configObject?: BuildConfiguration<FactoryResultType>
 ): ((
   buildTimeConfig?: BuildTimeConfig<FactoryResultType>
 ) => FactoryResultType) => {
+  const config = (typeof factoryNameOrConfig === 'string'
+    ? configObject
+    : factoryNameOrConfig) as BuildConfiguration<FactoryResultType>;
+
   let sequenceCounter = 0;
 
   const expandConfigFields = (


### PR DESCRIPTION
As raised in #238, it's not actually used (it was envisaged to be used
for debugging in some form) so let's make it optional. I suspect in the
next major version it will be removed.
