### PR TITLE
export BuildTimeConfig to avoid issue on libs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ interface Overrides<FactoryResultType> {
   [x: string]: Field;
 }
 
-interface BuildTimeConfig<FactoryResultType> {
+export interface BuildTimeConfig<FactoryResultType> {
   overrides?: Overrides<FactoryResultType>;
   map?: (builtThing: FactoryResultType) => FactoryResultType;
   traits?: string | string[];


### PR DESCRIPTION
When using this lib on a package, typescript throws the following error if declaration flag is on:
"Exported variable 'X' has or is using name 'BuildTimeConfig' from external module "path-to-project/node_modules/@jackfranklin/test-data-bot/build/index" but cannot be named."

As reported on this issue (https://github.com/microsoft/TypeScript/issues/5711) one possible solution is to have the interface exported.