### PR TITLE
Improve type safety

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -416,9 +416,7 @@ describe('test-data-bot', () => {
 
       interface User {
         name: string;
-        friends: {
-          names: Friend[];
-        };
+        friends: Friend[];
       }
 
       const friendBuilder = build<Friend>('Friend', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,20 +32,14 @@ export type FieldGenerator =
   | OneOfGenerator
   | PerBuildGenerator;
 
-export type Field =
-  | string
-  | number
-  | null
-  | FieldGenerator
-  | { [x: string]: Field | any }
-  | any[];
+export type Field<T = any> = T | FieldGenerator | FieldsConfiguration<T>;
 
 export type FieldsConfiguration<FactoryResultType> = {
-  readonly [Key in keyof FactoryResultType]: FactoryResultType[Key] | Field;
+  readonly [Key in keyof FactoryResultType]: Field<FactoryResultType[Key]>;
 };
 
-export type Overrides<FactoryResultType> = {
-  [Key in keyof FactoryResultType]?: FactoryResultType[Key] | Field;
+export type Overrides<FactoryResultType = any> = {
+  [Key in keyof FactoryResultType]?: Field<FactoryResultType[Key]>;
 };
 
 export interface BuildTimeConfig<FactoryResultType> {
@@ -85,8 +79,8 @@ const buildTimeTraitsArray = <FactoryResultType>(
 };
 
 const getValueOrOverride = (
-  overrides: Overrides<any>,
-  traitOverrides: Overrides<any>,
+  overrides: Overrides,
+  traitOverrides: Overrides,
   fieldValue: Field,
   fieldKey: string
 ): Field => {
@@ -150,9 +144,7 @@ export const build = <FactoryResultType>(
     return finalBuiltThing;
   };
 
-  const expandConfigField = (
-    fieldValue: ValueOf<FieldsConfiguration<FactoryResultType>>
-  ): any => {
+  const expandConfigField = (fieldValue: Field): any => {
     let calculatedValue;
 
     if (isGenerator(fieldValue)) {
@@ -189,10 +181,7 @@ export const build = <FactoryResultType>(
       // as typeof null === 'object'
       calculatedValue = fieldValue;
     } else if (typeof fieldValue === 'object') {
-      const nestedFieldsObject =
-        fieldValue as FieldsConfiguration<FactoryResultType>;
-
-      calculatedValue = expandConfigFields(nestedFieldsObject);
+      calculatedValue = expandConfigFields(fieldValue);
     } else {
       calculatedValue = fieldValue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,11 +91,11 @@ const getValueOrOverride = (
   fieldKey: string
 ): Field => {
   if (Object.keys(overrides).includes(fieldKey)) {
-    return overrides[fieldKey] as Field;
+    return overrides[fieldKey];
   }
 
   if (Object.keys(traitOverrides).includes(fieldKey)) {
-    return traitOverrides[fieldKey] as Field;
+    return traitOverrides[fieldKey];
   }
 
   return fieldValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export type FieldsConfiguration<FactoryResultType> = {
 };
 
 export type Overrides<FactoryResultType> = {
-  [x in keyof FactoryResultType]: Field;
+  [x in keyof FactoryResultType]?: Field;
 };
 
 export interface BuildTimeConfig<FactoryResultType> {
@@ -91,11 +91,11 @@ const getValueOrOverride = (
   fieldKey: string
 ): Field => {
   if (Object.keys(overrides).includes(fieldKey)) {
-    return overrides[fieldKey];
+    return overrides[fieldKey] as Field;
   }
 
   if (Object.keys(traitOverrides).includes(fieldKey)) {
-    return traitOverrides[fieldKey];
+    return traitOverrides[fieldKey] as Field;
   }
 
   return fieldValue;
@@ -122,18 +122,19 @@ export const build = <FactoryResultType>(
 
       const traitsArray = buildTimeTraitsArray(buildTimeConfig);
 
-      const traitOverrides: Overrides<FactoryResultType> = traitsArray.reduce<
-        Overrides<FactoryResultType>
-      >((overrides, currentTraitKey) => {
-        const hasTrait = config.traits && config.traits[currentTraitKey];
-        if (!hasTrait) {
-          console.warn(`Warning: trait '${currentTraitKey}' not found.`);
-        }
-        const traitsConfig = config.traits
-          ? config.traits[currentTraitKey]
-          : {};
-        return { ...overrides, ...(traitsConfig.overrides || {}) };
-      }, {});
+      const traitOverrides = traitsArray.reduce<Overrides<FactoryResultType>>(
+        (overrides, currentTraitKey) => {
+          const hasTrait = config.traits && config.traits[currentTraitKey];
+          if (!hasTrait) {
+            console.warn(`Warning: trait '${currentTraitKey}' not found.`);
+          }
+          const traitsConfig = config.traits
+            ? config.traits[currentTraitKey]
+            : {};
+          return { ...overrides, ...(traitsConfig.overrides || {}) };
+        },
+        {}
+      );
 
       const valueOrOverride = getValueOrOverride(
         overrides,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,11 @@ export type Field =
   | any[];
 
 export type FieldsConfiguration<FactoryResultType> = {
-  readonly [x in keyof FactoryResultType]: Field;
+  readonly [Key in keyof FactoryResultType]: FactoryResultType[Key] | Field;
 };
 
 export type Overrides<FactoryResultType> = {
-  [x in keyof FactoryResultType]?: Field;
+  [Key in keyof FactoryResultType]?: FactoryResultType[Key] | Field;
 };
 
 export interface BuildTimeConfig<FactoryResultType> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,19 +44,19 @@ export type FieldsConfiguration<FactoryResultType> = {
   readonly [x in keyof FactoryResultType]: Field;
 };
 
-export interface Overrides {
-  [x: string]: Field;
-}
+export type Overrides<FactoryResultType> = {
+  [x in keyof FactoryResultType]: Field;
+};
 
 export interface BuildTimeConfig<FactoryResultType> {
-  overrides?: Overrides;
+  overrides?: Overrides<FactoryResultType>;
   map?: (builtThing: FactoryResultType) => FactoryResultType;
   traits?: string | string[];
 }
 
 export interface TraitsConfiguration<FactoryResultType> {
   readonly [traitName: string]: {
-    overrides?: Overrides;
+    overrides?: Overrides<FactoryResultType>;
     postBuild?: (builtThing: FactoryResultType) => FactoryResultType;
   };
 }
@@ -85,8 +85,8 @@ const buildTimeTraitsArray = <FactoryResultType>(
 };
 
 const getValueOrOverride = (
-  overrides: Overrides,
-  traitOverrides: Overrides,
+  overrides: Overrides<any>,
+  traitOverrides: Overrides<any>,
   fieldValue: Field,
   fieldKey: string
 ): Field => {
@@ -122,19 +122,18 @@ export const build = <FactoryResultType>(
 
       const traitsArray = buildTimeTraitsArray(buildTimeConfig);
 
-      const traitOverrides: Overrides = traitsArray.reduce<Overrides>(
-        (overrides, currentTraitKey) => {
-          const hasTrait = config.traits && config.traits[currentTraitKey];
-          if (!hasTrait) {
-            console.warn(`Warning: trait '${currentTraitKey}' not found.`);
-          }
-          const traitsConfig = config.traits
-            ? config.traits[currentTraitKey]
-            : {};
-          return { ...overrides, ...(traitsConfig.overrides || {}) };
-        },
-        {}
-      );
+      const traitOverrides: Overrides<FactoryResultType> = traitsArray.reduce<
+        Overrides<FactoryResultType>
+      >((overrides, currentTraitKey) => {
+        const hasTrait = config.traits && config.traits[currentTraitKey];
+        if (!hasTrait) {
+          console.warn(`Warning: trait '${currentTraitKey}' not found.`);
+        }
+        const traitsConfig = config.traits
+          ? config.traits[currentTraitKey]
+          : {};
+        return { ...overrides, ...(traitsConfig.overrides || {}) };
+      }, {});
 
       const valueOrOverride = getValueOrOverride(
         overrides,


### PR DESCRIPTION
Hi!

As outlined in https://github.com/jackfranklin/test-data-bot/issues/270, the current fields and override types are not very strict. This is an attempt at starting to remedy that.

- Fixes an incorrect type in the test file. (`user.friends` was incorrectly typed as an object instead of an array).
- Enforces the field types for `fields` and `overrides` to be the correct type. The `FieldGenerator` is not yet typesafe, but shouldn't be fairly straightforward to fix as a next step.