### PR TITLE
Make generators type-safe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { mapValues } from 'lodash';
 
-export type SequenceFunction<T> = (counter: number) => T;
-
 export interface SequenceGenerator<T> {
   generatorType: 'sequence';
   call: (counter: number) => T;
@@ -209,7 +207,7 @@ export const bool = () => oneOf(true, false);
 
 type Sequence = {
   (): SequenceGenerator<number>;
-  <T>(userProvidedFunction: SequenceFunction<T>): SequenceGenerator<T>;
+  <T>(userProvidedFunction: (count: number) => T): SequenceGenerator<T>;
 };
 
 export const sequence = ((userProvidedFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ export const bool = () => oneOf(true, false);
 
 type Sequence = {
   (): SequenceGenerator<number>;
-  <T>(userProvidedFunction?: SequenceFunction<T>): SequenceGenerator<T>;
+  <T>(userProvidedFunction: SequenceFunction<T>): SequenceGenerator<T>;
 };
 
 export const sequence = ((userProvidedFunction) => {


### PR DESCRIPTION
All right, so this updates all the built-in generators to to be fully type-safe.

To be able to do this more easily and to simplify the code, the generators no longer save a copy of the input on themselves, but instead leverages closure and the passed argument directly.

I'm not sure whether the additional saved values were intentional, but I couldn't see anything for them in the tests. Feel free to push back on this if there is a reason to keep them.