### PR TITLE
Remove factory name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,15 +84,10 @@ const getValueOrOverride = (
 };
 
 export const build = <FactoryResultType>(
-  factoryNameOrConfig: string | BuildConfiguration<FactoryResultType>,
-  configObject?: BuildConfiguration<FactoryResultType>
+  config: BuildConfiguration<FactoryResultType>
 ): ((
   buildTimeConfig?: BuildTimeConfig<FactoryResultType>
 ) => FactoryResultType) => {
-  const config = (
-    typeof factoryNameOrConfig === 'string' ? configObject : factoryNameOrConfig
-  ) as BuildConfiguration<FactoryResultType>;
-
   let sequenceCounter = 0;
 
   const expandConfigFields = (


### PR DESCRIPTION
Removes the unused factory name argument. This simplifies the `build` function arguments.