### PR TITLE
added ability to reset builder sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ const userTwo = userBuilder();
 // userTwo.email === jack2@gmail.com
 ```
 
+You can use the `reset` method to reset the counter used internally when generating a sequence:
+
+```js
+const { build, sequence } = require('@jackfranklin/test-data-bot');
+
+const userBuilder = build('User', {
+  fields: {
+    id: sequence(),
+  },
+});
+
+const userOne = userBuilder();
+const userTwo = userBuilder();
+userBuilder.reset();
+const userThree = userBuilder();
+const userFour = userBuilder();
+
+// userOne.id === 1
+// userTwo.id === 2
+// userThree.id === 1 <- the sequence has been reset here
+// userFour.id === 2
+```
+
 ### Randomly picking between an option
 
 If you want an object to have a random value, picked from a list you control, you can use `oneOf`:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -221,6 +221,44 @@ describe('test-data-bot', () => {
       const users = [userBuilder(), userBuilder()];
       expect(users).toEqual([{ id: 10 }, { id: 20 }]);
     });
+    it('can have the sequence be manually reset', () => {
+      interface User {
+        id: number;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          id: sequence((x) => x ** 2),
+        },
+      });
+
+      const usersGroup1 = [userBuilder(), userBuilder(), userBuilder()];
+      expect(usersGroup1).toEqual([{ id: 1 }, { id: 4 }, { id: 9 }]);
+
+      userBuilder.reset();
+
+      const usersGroup2 = [userBuilder(), userBuilder(), userBuilder()];
+      expect(usersGroup2).toEqual([{ id: 1 }, { id: 4 }, { id: 9 }]);
+    });
+    it('can have a simple sequence be manually reset', () => {
+      interface User {
+        id: number;
+      }
+
+      const userBuilder = build<User>('User', {
+        fields: {
+          id: sequence(),
+        },
+      });
+
+      const usersGroup1 = [userBuilder(), userBuilder(), userBuilder()];
+      expect(usersGroup1).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+      userBuilder.reset();
+
+      const usersGroup2 = [userBuilder(), userBuilder(), userBuilder()];
+      expect(usersGroup2).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    });
   });
 
   describe('mapping', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,12 +91,15 @@ function mapValues<InputObject, Key extends keyof InputObject>(
   }, {} as { [key in Key]: unknown });
 }
 
+export interface Builder<FactoryResultType> {
+  (buildTimeConfig?: BuildTimeConfig<FactoryResultType>): FactoryResultType;
+  reset(): void;
+}
+
 export const build = <FactoryResultType>(
   factoryNameOrConfig: string | BuildConfiguration<FactoryResultType>,
   configObject?: BuildConfiguration<FactoryResultType>
-): ((
-  buildTimeConfig?: BuildTimeConfig<FactoryResultType>
-) => FactoryResultType) => {
+): Builder<FactoryResultType> => {
   const config = (
     typeof factoryNameOrConfig === 'string' ? configObject : factoryNameOrConfig
   ) as BuildConfiguration<FactoryResultType>;
@@ -171,7 +174,9 @@ export const build = <FactoryResultType>(
     return fieldValue;
   };
 
-  return (buildTimeConfig = {}) => {
+  const builder = (
+    buildTimeConfig: BuildTimeConfig<FactoryResultType> = {}
+  ) => {
     const fieldsToReturn = expandConfigFields(config.fields, buildTimeConfig);
 
     const traitsArray = buildTimeTraitsArray(buildTimeConfig);
@@ -192,6 +197,10 @@ export const build = <FactoryResultType>(
 
     return buildTimeMapFunc(postBuild(afterTraitPostBuildFields));
   };
+  builder.reset = () => {
+    sequenceCounter = 0;
+  };
+  return builder;
 };
 
 export const oneOf = <T>(...options: T[]): OneOfGenerator<T> => {


### PR DESCRIPTION
Closes #648 
Added a `reset` method to the return type of `build` that resets the sequence counter, making it possible to reset a builder between tests, e.g.:

```js
beforeEach(() => userBuilder.reset())
```