### PR TITLE
Fix incorrect overriding of `Date` fields.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,10 @@ export const build = <FactoryResultType>(
       return fieldValue;
     }
 
+    if (fieldValue instanceof Date) {
+      return fieldValue;
+    }
+
     if (typeof fieldValue === 'object') {
       return expandConfigFields(fieldValue);
     }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -723,3 +723,27 @@ tap.test('logs a warning if you pass a trait that was not defined', (t) => {
   );
   t.end();
 });
+
+tap.test('dates can be created and overwritten correctly', (t) => {
+  interface Plan {
+    createdAt: Date;
+  }
+
+  const planBuilder = build<Plan>('Plan', {
+    fields: {
+      createdAt: perBuild(() => new Date()),
+    },
+  });
+
+  const plan = planBuilder();
+  t.type(plan.createdAt, 'Date');
+
+  const planWithCustomDate = planBuilder({
+    overrides: {
+      createdAt: new Date(),
+    },
+  });
+  t.type(planWithCustomDate.createdAt, 'Date');
+
+  t.end();
+});


### PR DESCRIPTION
Any time a date value was overridden the resulting field would be given the value `{}`, we were incorrectly treating the date like a plain old object and trying to iterate through its key value pairs. If we hit a date we should just return it as is.

Fixes #806.